### PR TITLE
Server names are now valid for Bazel version 0.29.0

### DIFF
--- a/src/main/java/kupusoglu/orhan/bazelize_maven_plugin/model/MavenServer.java
+++ b/src/main/java/kupusoglu/orhan/bazelize_maven_plugin/model/MavenServer.java
@@ -68,7 +68,7 @@ public class MavenServer implements Comparable<MavenServer> {
     public String outputAsBazelServer() {
         String contentServer = Common.getTemplateServer();
 
-        contentServer = contentServer.replaceFirst("#SERVER_NAME#", this.name)
+        contentServer = contentServer.replaceFirst("#SERVER_NAME#", Common.sanitize(this.name))
                                      .replaceFirst("#SERVER_URL#", this.url);
 
         if (this.settings_file == null || this.settings_file.isEmpty()) {


### PR DESCRIPTION
Server names are not allowed to contain hyphens in Bazel v0.29.0 . Therefore we should use underscores.